### PR TITLE
[1813][FEATURE] - Add $BUSD as default output token for BNB Chain swaps

### DIFF
--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -1,5 +1,4 @@
 import {
-  BNB,
   ChainId,
   Currency,
   CurrencyAmount,
@@ -105,7 +104,7 @@ export const PRE_SELECT_OUTPUT_CURRENCY_ID: { [chainId in ChainId]: string } = {
   [ChainId.ARBITRUM_ONE]: USDC[ChainId.ARBITRUM_ONE].address,
   [ChainId.POLYGON]: WETH[ChainId.POLYGON].address,
   [ChainId.OPTIMISM_MAINNET]: OP[ChainId.OPTIMISM_MAINNET].address,
-  [ChainId.BSC_MAINNET]: BNB.address!,
+  [ChainId.BSC_MAINNET]: DAI[ChainId.BSC_MAINNET].address,
   [ChainId.RINKEBY]: '',
   [ChainId.ARBITRUM_RINKEBY]: '',
   [ChainId.GOERLI]: '',

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -104,7 +104,7 @@ export const PRE_SELECT_OUTPUT_CURRENCY_ID: { [chainId in ChainId]: string } = {
   [ChainId.ARBITRUM_ONE]: USDC[ChainId.ARBITRUM_ONE].address,
   [ChainId.POLYGON]: WETH[ChainId.POLYGON].address,
   [ChainId.OPTIMISM_MAINNET]: OP[ChainId.OPTIMISM_MAINNET].address,
-  [ChainId.BSC_MAINNET]: DAI[ChainId.BSC_MAINNET].address,
+  [ChainId.BSC_MAINNET]: Token.BUSD[ChainId.BSC_MAINNET].address,
   [ChainId.RINKEBY]: '',
   [ChainId.ARBITRUM_RINKEBY]: '',
   [ChainId.GOERLI]: '',


### PR DESCRIPTION
## Fixes: #1813 

# Description

* Added ~$DAI~  $BUSD (per @berteotti request) as default output token for BNB Chain swaps

![image](https://github.com/SwaprHQ/swapr-dapp/assets/21271189/e13a68e8-56a7-47a7-af2d-0b2a717ca0b8)


# How to test the changes

1) Pull this branch
2) Run the project locally
3) Go to Swapr landing page
4) Connect your wallet and select BNB Chain
5) **$BNB** should be preselected as default **INPUT** token and **$BUSD** should be preselected as default **OUTPUT** token
