### PR TITLE
[SWA-31][FEAT] - Remove $DXD from common base swap tokens

### DIFF
--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -168,7 +168,6 @@ export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
 // by default, so no need to add the wrapper to the list)
 export const SUGGESTED_BASES: ChainTokenList = {
   [ChainId.MAINNET]: [
-    DXD[ChainId.MAINNET],
     DAI[ChainId.MAINNET],
     USDC[ChainId.MAINNET],
     USDT[ChainId.MAINNET],
@@ -178,7 +177,6 @@ export const SUGGESTED_BASES: ChainTokenList = {
   [ChainId.RINKEBY]: [],
   [ChainId.ARBITRUM_ONE]: [
     WETH[ChainId.ARBITRUM_ONE],
-    DXD[ChainId.ARBITRUM_ONE],
     SWPR[ChainId.ARBITRUM_ONE],
     WBTC[ChainId.ARBITRUM_ONE],
     USDC[ChainId.ARBITRUM_ONE],
@@ -186,7 +184,7 @@ export const SUGGESTED_BASES: ChainTokenList = {
   ],
   [ChainId.ARBITRUM_RINKEBY]: [WETH[ChainId.ARBITRUM_RINKEBY], DXD[ChainId.ARBITRUM_RINKEBY]],
   [ChainId.ARBITRUM_GOERLI]: [WETH[ChainId.ARBITRUM_GOERLI]],
-  [ChainId.XDAI]: [WXDAI[ChainId.XDAI], DXD[ChainId.XDAI], WETH[ChainId.XDAI], USDC[ChainId.XDAI], SWPR[ChainId.XDAI]],
+  [ChainId.XDAI]: [WXDAI[ChainId.XDAI], WETH[ChainId.XDAI], USDC[ChainId.XDAI], SWPR[ChainId.XDAI]],
   [ChainId.POLYGON]: [
     WMATIC[ChainId.POLYGON],
     WETH[ChainId.POLYGON],


### PR DESCRIPTION
## Fixes: [SWA-31](https://linear.app/swaprdev/issue/SWA-31/remove-dxd-from-common-tokens)

# Description

* Remove $DXD as a common base swap token from Mainnet, Arbitrum One and Gnosis Chain

![image](https://github.com/SwaprHQ/swapr-dapp/assets/21271189/fb8b78f0-14a1-4afd-86eb-df09cb62d20f)

# How to test the changes

1) Pull this branch
2) Run the project locally
3) Go to Swapr landing page
4) Connect your wallet and select any of the following: Mainnet, Arbitrum One or Gnosis Chain
5) **$DXD** should NOT be present in the "Common list" for suggested base tokens on the swap
