### PR TITLE
[SWA-64] Rearrange header

### DIFF
--- a/src/components/Header/MobileOptions.tsx
+++ b/src/components/Header/MobileOptions.tsx
@@ -80,6 +80,13 @@ export default function MobileOptions() {
         content={
           <List>
             <ListItem>
+              <StyledExternalLink id="stackly-nav-link" href="https://stackly.eth.limo/">
+                {t('DCA')}
+                <span>↗</span>
+              </StyledExternalLink>
+            </ListItem>
+
+            <ListItem>
               <StyledExternalLink id="charts-nav-link" href="https://dxstats.eth.limo/">
                 {t('charts')}
                 <span>↗</span>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -263,6 +263,9 @@ function Header() {
           <HeaderLink data-testid="swap-nav-link" id="swap-nav-link" to={swapRoute}>
             {t('swap')}
           </HeaderLink>
+          <HeaderLink data-testid="bridge-nav-link" id="bridge-nav-link" to="/bridge">
+            {t('bridge')}
+          </HeaderLink>
           <HeaderLink
             data-testid="pool-nav-link"
             id="pool-nav-link"
@@ -278,9 +281,11 @@ function Header() {
             {t('rewards')}
             {networkWithoutSWPR && <HeaderLinkBadge label="NOT&nbsp;AVAILABLE" />}
           </HeaderLink>
-          <HeaderLink data-testid="bridge-nav-link" id="bridge-nav-link" to="/bridge">
-            {t('bridge')}
-            <HeaderLinkBadge label="BETA" />
+          <HeaderLink id="stackly-nav-link" href="https://stackly.eth.limo/">
+            {t('DCA')}
+            <Text ml="4px" fontSize="13px">
+              ↗
+            </Text>
           </HeaderLink>
           <HeaderLink id="vote-nav-link" href="https://snapshot.org/#/swpr.eth">
             {t('vote')}
@@ -347,6 +352,9 @@ function Header() {
           <HeaderMobileLink id="swap-nav-link" to="/swap">
             {t('swap')}
           </HeaderMobileLink>
+          <HeaderMobileLink id="bridge-nav-link" to="/bridge">
+            {t('bridge')}
+          </HeaderMobileLink>
           {!networkWithoutSWPR && (
             <HeaderMobileLink id="pool-nav-link" to="/pools">
               {t('liquidity')}
@@ -357,9 +365,6 @@ function Header() {
               {t('rewards')}
             </HeaderMobileLink>
           )}
-          <HeaderMobileLink id="bridge-nav-link" to="/bridge">
-            {t('bridge')}
-          </HeaderMobileLink>
           <HeaderMobileLink id="vote-nav-link" href={`https://snapshot.org/#/swpr.eth`}>
             {t('vote')}
             <Text ml="4px" fontSize="11px">


### PR DESCRIPTION
## Fixes: SWA-64

# Description

Update the header. Move bridge near Swap.
Add DCA to header

![image](https://github.com/SwaprHQ/swapr-dapp/assets/55109759/3ab215c1-88f6-45a4-acff-7fe481214e87)

![image](https://github.com/SwaprHQ/swapr-dapp/assets/55109759/b9c9343f-4cc3-4874-a4dc-ad13c88c66c0)


# How to test the changes

Check if DCA is seen and accessible
