### PR TITLE
[SWA-96][FEAT] - Add native $USDC on Optimism

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@reduxjs/toolkit": "^1.9.5",
     "@swapr/core": "^0.3.19",
     "@swapr/periphery": "^0.3.22",
-    "@swapr/sdk": "1.9.1",
+    "@swapr/sdk": "SwaprHQ/swapr-sdk#feat/swa-96-add-support-for-native-usdc-in-optimism",
     "@tanstack/react-query": "4.24.6",
     "@uniswap/token-lists": "^1.0.0-beta.27",
     "@uniswap/v3-periphery": "1.4.1",

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -82,6 +82,14 @@ export const ARBITRUM_NATIVE_USDC = new Token(
   'USD Coin'
 )
 
+export const OPTIMISM_NATIVE_USDC = new Token(
+  ChainId.OPTIMISM_MAINNET,
+  '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
+  6,
+  'USDC',
+  'USD Coin'
+)
+
 export const HONEY = new Token(ChainId.XDAI, '0x71850b7E9Ee3f13Ab46d67167341E4bDc905Eef9', 18, 'HNY', 'Honey')
 
 export const STAKE = new Token(
@@ -207,6 +215,7 @@ export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
   [ChainId.OPTIMISM_GOERLI]: [],
   [ChainId.OPTIMISM_MAINNET]: [
     USDC[ChainId.OPTIMISM_MAINNET],
+    OPTIMISM_NATIVE_USDC,
     USDT[ChainId.OPTIMISM_MAINNET],
     WBTC[ChainId.OPTIMISM_MAINNET],
   ],
@@ -259,6 +268,7 @@ export const SUGGESTED_BASES: ChainTokenList = {
     OP[ChainId.OPTIMISM_MAINNET],
     DAI[ChainId.OPTIMISM_MAINNET],
     USDC[ChainId.OPTIMISM_MAINNET],
+    OPTIMISM_NATIVE_USDC,
     USDT[ChainId.OPTIMISM_MAINNET],
     WBTC[ChainId.OPTIMISM_MAINNET],
   ],


### PR DESCRIPTION
## Fixes: [SWA-96](https://linear.app/swaprhq/issue/SWA-96/add-support-for-native-dollarusdc-in-optimism)

# Description

* Add $USDC native token in Arbitrum

# How to test the changes

1) Pull this branch
2) Run the project locally
3) Go to Swapr landing page
4) Connect your wallet
5) $USDC and $USDC.e tokens should be among the common tokens suggested for swaps on Optimism Mainnet