### PR TITLE
[SWA-131][FIX] - Update background in Popups to be as intended

### DIFF
--- a/src/state/application/hooks.tsx
+++ b/src/state/application/hooks.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Id, toast } from 'react-toastify'
 
+import LiquidityV3Bg from '../../assets/images/liquidity-v3-bg.svg'
 import { LiquidityV3Popup } from '../../components/Popups/LiquidityV3Popup'
 import { NotificationPopup } from '../../components/Popups/NotificationPopup'
 import { StacklyPopup } from '../../components/Popups/StacklyPopup'
@@ -118,8 +119,9 @@ export function useLiquidityV3Popup() {
       autoClose: false,
       icon: false,
       position: toast.POSITION.BOTTOM_RIGHT,
-      progressStyle: {
-        background: 'hsla(0,0%,100%,.7)',
+      style: {
+        background: `url(${LiquidityV3Bg})`,
+        backgroundRepeat: 'round',
       },
     })
 }

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -9,7 +9,6 @@ import styled, {
   ThemeProvider as StyledComponentsThemeProvider,
 } from 'styled-components'
 
-import LiquidityV3Bg from '../assets/images/liquidity-v3-bg.svg'
 import { useIsDarkMode } from '../state/user/hooks'
 import { breakpoints } from '../utils/theme'
 
@@ -398,8 +397,6 @@ body {
 }
 
 .custom-toast-container {
-  background: url(${LiquidityV3Bg});
-  background-repeat: round;
   box-shadow: 0px 16px 12px ${({ theme }) => transparentize(0.55, theme.boxShadow)};
   border-radius: 12px !important;
 }
@@ -418,6 +415,10 @@ body {
   @media screen and (max-width: ${breakpoints.md}) {
     padding: 10px
   }
+}
+
+.Toastify__toast--info {
+  background: ${props => props.theme.bg1};
 }
 
 .Toastify__close-button {


### PR DESCRIPTION
## Fixes: [SWA-131](https://linear.app/swaprhq/issue/SWA-131/wrong-popup-global-background)

# Description
* Update background in Popups to be as intended

# Visual evidence
![image](https://github.com/SwaprHQ/swapr-dapp/assets/21271189/3b0b733c-f3c2-4d59-b5c2-e47906ab1037)

# How to test the changes

1) Pull this branch
2) Run the project locally
3) Go to Swapr landing page
4) Connect your wallet
5) All the popups should have their corresponding backgrounds: Liquidity V3 should have the black&purple and the TX popup should have it's dark gray background