### PR TITLE
[SWA-141][FEAT] - Change default Gnosis Chain output token to $WETH

### DIFF
--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -7,7 +7,6 @@ import {
   CurrencyAmount,
   DAI,
   DXD,
-  GNO,
   SWPR,
   USDC,
   USDT,

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -162,7 +162,7 @@ export const PRE_SELECT_OUTPUT_CURRENCY_ID: { [chainId in ChainId]: string } = {
   [ChainId.ARBITRUM_RINKEBY]: '',
   [ChainId.BSC_MAINNET]: BUSD[ChainId.BSC_MAINNET].address,
   [ChainId.BSC_TESTNET]: '',
-  [ChainId.GNOSIS]: GNO.address,
+  [ChainId.GNOSIS]: WETH[ChainId.GNOSIS].address,
   [ChainId.GOERLI]: '',
   [ChainId.MAINNET]: DAI[ChainId.MAINNET].address,
   [ChainId.OPTIMISM_GOERLI]: '',


### PR DESCRIPTION
## Fixes: [SWA-141](https://linear.app/swaprhq/issue/SWA-141/change-default-tokens-to-xdai-weth-on-gnosis-chain)

# Description

* Update the pre-selected output currency for Gnosis, to be WETH

# Visual Evidence
![image](https://github.com/SwaprHQ/swapr-dapp/assets/21271189/8daa6345-01b9-4917-b3b8-3d8c1655ef71)


# How to test the changes

1) Pull this branch
2) Run the project locally
3) Go to Swapr dapp page
4) Connect your wallet
5) For Gnosis Chain, you should see pre-selected $XDAI (native token) as the input token and $WETH as the output token in the Swapbox