### PR TITLE
fix: bg image on big screens

### DIFF
--- a/src/components/SpaceBg/SpaceBg.tsx
+++ b/src/components/SpaceBg/SpaceBg.tsx
@@ -23,4 +23,8 @@ const StyledHero = styled.div<{ isAdvancedTradeMode: boolean }>`
   background-position: top center;
   width: 100%;
   min-height: calc(100vh - 218px);
+
+  @media (min-width: 2000px) {
+    background-size: cover;
+  }
 `


### PR DESCRIPTION
## previous

<img width="1889" alt="image" src="https://github.com/SwaprHQ/swapr-dapp/assets/5664434/b103062d-d4d2-482a-b80c-cda4345e3ebc">


## now
<img width="1913" alt="image" src="https://github.com/SwaprHQ/swapr-dapp/assets/5664434/f63c5ec0-f09c-49ca-9105-39633e546651">
