### PR TITLE
chore: update swapr sdk 1.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@reduxjs/toolkit": "^1.9.5",
     "@swapr/core": "^0.3.19",
     "@swapr/periphery": "^0.3.22",
-    "@swapr/sdk": "1.11.1",
+    "@swapr/sdk": "1.11.2",
     "@tanstack/react-query": "4.24.6",
     "@uniswap/token-lists": "^1.0.0-beta.27",
     "@uniswap/v3-periphery": "1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8429,7 +8429,7 @@ __metadata:
     "@storybook/testing-library": 0.1.0
     "@swapr/core": ^0.3.19
     "@swapr/periphery": ^0.3.22
-    "@swapr/sdk": 1.11.1
+    "@swapr/sdk": 1.11.2
     "@synthetixio/synpress": ^2.3.3
     "@tanstack/react-query": 4.24.6
     "@testing-library/cypress": ^9.0.0
@@ -8570,9 +8570,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swapr/sdk@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@swapr/sdk@npm:1.11.1"
+"@swapr/sdk@npm:1.11.2":
+  version: 1.11.2
+  resolution: "@swapr/sdk@npm:1.11.2"
   dependencies:
     "@cowprotocol/cow-sdk": ^1.0.2-RC.0
     "@ethersproject/abi": ^5.6.4
@@ -8603,7 +8603,7 @@ __metadata:
     tslib: ^2.3.1
   peerDependencies:
     ethers: ^5.4.0
-  checksum: e186cc8343bb1155617145baffe34af7f8c4d1ad89f6da06d4805825043b2b4ecec6d65d589920a9da40683d9418d96dadede15d7a0f40d11435a7752f9cb696
+  checksum: 19660463648570b36dc654dbd59c1da5bcf6ed7ec321a39dd9fc370ff6770fd1f2a4886c64b32ae1ccf551735f619b1a180453f7c0f72668216593159eabafe2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update Swapr SDK to 1.11.2
